### PR TITLE
Containerized front end

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,16 @@
+FROM node:17-alpine3.14 as build
+
+WORKDIR /usr/local/app
+
+ENV NODE_OPTIONS=--openssl-legacy-provider
+
+COPY  ./ /usr/local/app/
+
+RUN npm install
+
+RUN npm run build
+
+
+FROM nginx:1.21.5-alpine
+
+COPY --from=build /usr/local/app/dist/* /usr/share/nginx/html


### PR DESCRIPTION
Building the Docker image of the front end:
`docker build -t expense_management_fe .`

Starting a Docker container, based on the just built image:
`docker run -d -p 4200:80 expense_management_fe`

The `-p` option specifies the port of the host and the port in the container, respectively. While the container's port must remain 80, the other one can be set to other values. 

If you visit `http://localhost:4200` the sign-in page is displayed. Be mindful that the `4200` should be replaced with the host port that you have set in the `docker run` command.